### PR TITLE
Null check on tokenTypeHint variable

### DIFF
--- a/api-security/org.wso2.carbon.identity.oauth.introspection/src/main/java/org/wso2/carbon/identity/oauth/introspection/IntrospectResource.java
+++ b/api-security/org.wso2.carbon.identity.oauth.introspection/src/main/java/org/wso2/carbon/identity/oauth/introspection/IntrospectResource.java
@@ -1,13 +1,6 @@
 package org.wso2.carbon.identity.oauth.introspection;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.jettison.json.JSONException;
@@ -16,8 +9,12 @@ import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 @Path("/")
-@Consumes({ MediaType.APPLICATION_FORM_URLENCODED })
+@Consumes({MediaType.APPLICATION_FORM_URLENCODED})
 @Produces(MediaType.APPLICATION_JSON)
 public class IntrospectResource {
 
@@ -27,84 +24,83 @@ public class IntrospectResource {
     private final static String JWT_TOKEN_TYPE = "JWT";
 
     /**
-     * 
-     * @param token The string value of the token. For access tokens, this is the "access_token" value returned from the
-     *        token end-point defined in OAuth 2.0 [RFC6749], Section 5.1. For refresh tokens, this is the
-     *        "refresh_token" value returned from the token end-point as defined in OAuth 2.0 [RFC6749], Section 5.1.
-     *        Other token types are outside the scope of this specification.
+     * @param token         The string value of the token. For access tokens, this is the "access_token" value returned from the
+     *                      token end-point defined in OAuth 2.0 [RFC6749], Section 5.1. For refresh tokens, this is the
+     *                      "refresh_token" value returned from the token end-point as defined in OAuth 2.0 [RFC6749], Section 5.1.
+     *                      Other token types are outside the scope of this specification.
      * @param tokenTypeHint A hint about the type of the token submitted for introspection. The protected resource MAY
-     *        pass this parameter to help the authorization server optimize the token lookup. If the server is unable to
-     *        locate the token using the given hint, it MUST extend its search across all of its supported token types.
-     *        An authorization server MAY ignore this parameter, particularly if it is able to detect the token type
-     *        automatically. Values for this field are defined in the "OAuth Token Type Hints" registry defined in OAuth
-     *        Token Revocation [RFC7009].
+     *                      pass this parameter to help the authorization server optimize the token lookup. If the server is unable to
+     *                      locate the token using the given hint, it MUST extend its search across all of its supported token types.
+     *                      An authorization server MAY ignore this parameter, particularly if it is able to detect the token type
+     *                      automatically. Values for this field are defined in the "OAuth Token Type Hints" registry defined in OAuth
+     *                      Token Revocation [RFC7009].
      * @return
      */
     @POST
     public Response introspect(@FormParam("token") String token, @FormParam("token_type_hint") String tokenTypeHint) {
 
-	OAuth2TokenValidationRequestDTO request;
-	OAuth2IntrospectionResponseDTO response;
+        OAuth2TokenValidationRequestDTO request;
+        OAuth2IntrospectionResponseDTO response;
 
-	// TODO: sanitize tokentypeHint
+        // TODO: sanitize tokentypeHint
 
-	if (log.isDebugEnabled()) {
-	    log.debug("Token type hint: " + tokenTypeHint);
-	}
+        if (log.isDebugEnabled()) {
+            log.debug("Token type hint: " + tokenTypeHint);
+        }
 
-	if (token == null || token.trim().length() == 0) {
-	    // Note that a properly formed and authorized query for an inactive or otherwise invalid token (or a token
-	    // the protected resource is not allowed to know about) is not considered an error response by this
-	    // specification.
-	    return Response.status(Response.Status.BAD_REQUEST).entity("{\"error\": \"Invalid input\"}").build();
-	}
+        if (token == null || token.trim().length() == 0) {
+            // Note that a properly formed and authorized query for an inactive or otherwise invalid token (or a token
+            // the protected resource is not allowed to know about) is not considered an error response by this
+            // specification.
+            return Response.status(Response.Status.BAD_REQUEST).entity("{\"error\": \"Invalid input\"}").build();
+        }
 
-	// first we need to validate the access token against the OAuth2TokenValidationService OSGi service.
+        // first we need to validate the access token against the OAuth2TokenValidationService OSGi service.
 
-	request = new OAuth2TokenValidationRequestDTO();
-	OAuth2TokenValidationRequestDTO.OAuth2AccessToken accessToken = request.new OAuth2AccessToken();
-	accessToken.setIdentifier(token);
+        request = new OAuth2TokenValidationRequestDTO();
+        OAuth2TokenValidationRequestDTO.OAuth2AccessToken accessToken = request.new OAuth2AccessToken();
+        accessToken.setIdentifier(token);
 
-	if(tokenTypeHint != null && !tokenTypeHint.isEmpty()) {
-		accessToken.setTokenType(tokenTypeHint);
-	}else {
-		accessToken.setTokenType("bearer");
-	}
+        if (!StringUtils.isBlank(tokenTypeHint)) {
+            accessToken.setTokenType(tokenTypeHint);
+        } else {
+            accessToken.setTokenType(DEFAULT_TOKEN_TYPE_HINT);
+        }
 
-	request.setAccessToken(accessToken);
+        request.setAccessToken(accessToken);
 
-	// get a reference to the OAuth2TokenValidationService OSGi service.
-	OAuth2TokenValidationService tokenService = (OAuth2TokenValidationService) PrivilegedCarbonContext
-		.getThreadLocalCarbonContext().getOSGiService(OAuth2TokenValidationService.class);
+        // get a reference to the OAuth2TokenValidationService OSGi service.
+        OAuth2TokenValidationService tokenService = (OAuth2TokenValidationService) PrivilegedCarbonContext
+                .getThreadLocalCarbonContext().getOSGiService(OAuth2TokenValidationService.class);
 
-	response = tokenService.buildIntrospectionResponse(request);
+        response = tokenService.buildIntrospectionResponse(request);
 
-	if (response.getError() != null) {
-	    if (log.isDebugEnabled()) {
-		log.debug("The error why token is made inactive: " + response.getError());
-	    }
-	    // the client needs not to know about why exactly the token is not active.
-	    return Response.status(Response.Status.OK).entity("{\"active\":false}").build();
-	}
+        if (response.getError() != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("The error why token is made inactive: " + response.getError());
+            }
+            // the client needs not to know about why exactly the token is not active.
+            return Response.status(Response.Status.OK).entity("{\"active\":false}").build();
+        }
 
-	IntrospectionResponseBuilder respBuilder = new IntrospectionResponseBuilder().setActive(response.isActive())
-		.setNotBefore(response.getNbf()).setScope(response.getScope()).setUsername(response.getUsername())
-		.setTokenType(DEFAULT_TOKEN_TYPE).setClientId(response.getClientId()).setIssuedAt(response.getIat())
-		.setExpiration(response.getExp());
+        IntrospectionResponseBuilder respBuilder = new IntrospectionResponseBuilder().setActive(response.isActive())
+                .setNotBefore(response.getNbf()).setScope(response.getScope()).setUsername(response.getUsername())
+                .setTokenType(DEFAULT_TOKEN_TYPE).setClientId(response.getClientId()).setIssuedAt(response.getIat())
+                .setExpiration(response.getExp());
 
-	if (accessToken.getTokenType().equalsIgnoreCase(JWT_TOKEN_TYPE)) {
-	    // we need to handle JWT token differently.
-	    // the introspection response has parameters specific to the JWT token.
-	    respBuilder.setAudience(response.getAud()).setJwtId(response.getJti()).setSubject(response.getSub())
-		    .setIssuer(response.getIss());
-	}
+        if (accessToken.getTokenType().equalsIgnoreCase(JWT_TOKEN_TYPE)) {
+            // we need to handle JWT token differently.
+            // the introspection response has parameters specific to the JWT token.
+            respBuilder.setAudience(response.getAud()).setJwtId(response.getJti()).setSubject(response.getSub())
+                    .setIssuer(response.getIss());
+        }
 
-	try {
-	    return Response.ok(respBuilder.build(), MediaType.APPLICATION_JSON).status(Response.Status.OK).build();
-	} catch (JSONException e) {
-	    log.error("Error occured while building the json response.", e);
-	    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-		    .entity("{'error': 'Error occured while building the json response.'}").build();
-	}
+        try {
+            return Response.ok(respBuilder.build(), MediaType.APPLICATION_JSON).status(Response.Status.OK).build();
+        } catch (JSONException e) {
+            log.error("Error occured while building the json response.", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("{'error': 'Error occured while building the json response.'}").build();
+        }
     }
 }

--- a/api-security/org.wso2.carbon.identity.oauth.introspection/src/main/java/org/wso2/carbon/identity/oauth/introspection/IntrospectResource.java
+++ b/api-security/org.wso2.carbon.identity.oauth.introspection/src/main/java/org/wso2/carbon/identity/oauth/introspection/IntrospectResource.java
@@ -9,7 +9,12 @@ import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 
-import javax.ws.rs.*;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 


### PR DESCRIPTION
When we build the token introspection component using JDK 1.8, it throws a below error,

`[2017-10-25 17:31:58,950] ERROR {org.apache.catalina.core.StandardWrapperValve} -  Servlet.service() for servlet [cxf] in context with path [/introspect] threw exception
java.lang.RuntimeException: org.apache.cxf.interceptor.Fault
	at org.apache.cxf.interceptor.AbstractFaultChainInitiatorObserver.onMessage(AbstractFaultChainInitiatorObserver.java:116)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:336)`

Furthermore, I  debugged the code and identified that the request hits the method with two parameters (i.e. introspect(@FormParam("token") String token, @FormParam("token_type_hint") String tokenTypeHint)) even if we send just one parameter (i.e Token) in JDK 1.8.

In order to fix the error, I removed the single parameter method (i.e introspect(@FormParam("token") String token) ) and added a null check on tokenTypeHint parameter string.

I  tested the component with both JDK 1.8 and JDK 1.7 it works fine with both versions now.
